### PR TITLE
Add test for machine parameter flattening

### DIFF
--- a/tests/test_machine_parameters.py
+++ b/tests/test_machine_parameters.py
@@ -1,0 +1,26 @@
+import pytest
+from am_machine import _flatten_parameters, machine_parameters_basic
+from basyx.aas import model
+
+
+def test_flatten_parameters_basic_subset():
+    expected = {
+        "manufacturer_brand": model.datatypes.String,
+        "model_type": model.datatypes.String,
+        "model_number": model.datatypes.String,
+        "serial_number": model.datatypes.String,
+        "feedstock_equipped": model.datatypes.String,
+        "remote_control": model.datatypes.Boolean,
+        "x_dimension": model.datatypes.Double,
+        "y_dimension": model.datatypes.Double,
+        "z_dimension": model.datatypes.Double,
+        "laser_source_model": model.datatypes.String,
+        "laser_source_rated_power": model.datatypes.Double,
+        "beam_focus_diameter_min": model.datatypes.Double,
+        "beam_focus_diameter_max": model.datatypes.Double,
+    }
+    flattened = _flatten_parameters(machine_parameters_basic)
+    for key, datatype in expected.items():
+        assert key in flattened, f"Missing parameter: {key}"
+        assert flattened[key] == datatype
+


### PR DESCRIPTION
## Summary
- test `_flatten_parameters` against a subset of `machine_parameters_basic`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852ce72bda0832699795e43da534da5